### PR TITLE
Fix cpu inference error & Improved readability of multispeaker results

### DIFF
--- a/pqmf.py
+++ b/pqmf.py
@@ -75,15 +75,15 @@ class PQMF(torch.nn.Module):
                 (-1) ** k * np.pi / 4)
 
         # convert to tensor
-        analysis_filter = torch.from_numpy(h_analysis).float().unsqueeze(1).cuda(device)
-        synthesis_filter = torch.from_numpy(h_synthesis).float().unsqueeze(0).cuda(device)
+        analysis_filter = torch.from_numpy(h_analysis).float().unsqueeze(1).to(device)
+        synthesis_filter = torch.from_numpy(h_synthesis).float().unsqueeze(0).to(device)
 
         # register coefficients as beffer
         self.register_buffer("analysis_filter", analysis_filter)
         self.register_buffer("synthesis_filter", synthesis_filter)
 
         # filter for downsampling & upsampling
-        updown_filter = torch.zeros((subbands, subbands, subbands)).float().cuda(device)
+        updown_filter = torch.zeros((subbands, subbands, subbands)).float().to(device)
         for k in range(subbands):
             updown_filter[k, k, 0] = 1.0
         self.register_buffer("updown_filter", updown_filter)


### PR DESCRIPTION
When inferring to cpu, I checked that 

```RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0! (when checking argument for argument index in method wrapper__index_select)```

appeared and could not be inferred. When converting to a tensor value, it was also changed to be converted according to the type of device. In addition, in order to make it easier to check the results of the multi-speaker at once, the names of the .wav files were set to the speaker's name, making it easier to see.